### PR TITLE
Add main entry point to bower definition

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,9 @@
   "moduleType": [
     "amd"
   ],
+  "main": [
+    "lib/VSS.SDK.js"
+  ],
   "typescript": {
     "definitions": [
         "typings/tfs.d.ts",


### PR DESCRIPTION
Add main entry point to bower.json to enable, e.g., wiredep to automatically import the SDK.